### PR TITLE
Honor the XDG base directory specification

### DIFF
--- a/src/Domain/VisConstants.h
+++ b/src/Domain/VisConstants.h
@@ -49,13 +49,13 @@ static const uint32_t k_default_high_cutoff_frequency = 22050;
 
 // config path defaults
 // http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-static const std::string k_default_config_path_root = std::getenv("XDG_CONFIG_HOME") ?
-    std::string(std::getenv("XDG_CONFIG_HOME")) : (std::string(std::getenv("HOME")) + "/.config");
-
-static const std::string k_default_config_path = k_default_config_path_root + "/vis/config";
-static const std::string k_colors_directory = k_default_config_path_root + "/vis/colors/";
-static const std::string k_default_colors_path = "colors";
-static const std::string k_default_log_path = k_default_config_path_root + "/vis/vis.log";
+static const char* k_xdg_config_home{std::getenv("XDG_CONFIG_HOME")};
+static const std::string k_default_config_path_root{k_xdg_config_home != nullptr ?
+        std::string(k_xdg_config_home) + "/vis" : std::string(std::getenv("HOME")) + "/.config/vis"};
+static const std::string k_default_config_path = k_default_config_path_root + "/config";
+static const std::string k_colors_directory{k_default_config_path_root + "/colors/"};
+static const std::string k_default_colors_path{"colors"};
+static const std::string k_default_log_path{k_default_config_path_root + "/vis.log"};
 
 // Default characters for visualizers
 static const wchar_t k_default_spectrum_character{k_space_wchar};

--- a/src/Domain/VisConstants.h
+++ b/src/Domain/VisConstants.h
@@ -48,10 +48,14 @@ static const uint32_t k_default_low_cutoff_frequency = 30;
 static const uint32_t k_default_high_cutoff_frequency = 22050;
 
 // config path defaults
-static const std::string k_default_config_path{".config/vis/config"};
-static const std::string k_colors_directory{".config/vis/colors/"};
-static const std::string k_default_colors_path{"colors"};
-static const std::string k_default_log_path{".config/vis/vis.log"};
+// http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+static const std::string k_default_config_path_root = std::getenv("XDG_CONFIG_HOME") ?
+    std::string(std::getenv("XDG_CONFIG_HOME")) : (std::string(std::getenv("HOME")) + "/.config");
+
+static const std::string k_default_config_path = k_default_config_path_root + "/vis/config";
+static const std::string k_colors_directory = k_default_config_path_root + "/vis/colors/";
+static const std::string k_default_colors_path = "colors";
+static const std::string k_default_log_path = k_default_config_path_root + "/vis/vis.log";
 
 // Default characters for visualizers
 static const wchar_t k_default_spectrum_character{k_space_wchar};

--- a/src/Utils/ConfigurationUtils.cpp
+++ b/src/Utils/ConfigurationUtils.cpp
@@ -246,8 +246,7 @@ vis::SmoothingMode vis::ConfigurationUtils::read_smoothing_mode(
 
 void vis::ConfigurationUtils::load_settings(Settings &settings)
 {
-    auto config_path = Utils::get_home_directory();
-    config_path.append(VisConstants::k_default_config_path);
+    auto config_path = VisConstants::k_default_config_path;
     load_settings(settings, config_path);
 }
 
@@ -361,8 +360,7 @@ void vis::ConfigurationUtils::load_settings(Settings &settings,
         Utils::get(properties, k_stereo_enabled_setting, true));
 
     // set color definitions
-    auto colors_path = Utils::get_home_directory();
-    colors_path.append(VisConstants::k_colors_directory);
+    auto colors_path = VisConstants::k_colors_directory;
     colors_path.append(Utils::get(properties, k_color_scheme_path_setting,
                                   VisConstants::k_default_colors_path));
     settings.set_colors(vis::ConfigurationUtils::read_colors(colors_path));

--- a/src/Utils/Logger.cpp
+++ b/src/Utils/Logger.cpp
@@ -26,7 +26,7 @@ vis::Logger::Logger()
 
 void vis::Logger::initialize(const std::string log_location)
 {
-    std::string log_path{Utils::get_home_directory()};
+    std::string log_path{VisConstants::k_default_log_path};
     log_path.append(log_location);
 
     // redirect stderr to log file

--- a/src/Utils/Utils.h
+++ b/src/Utils/Utils.h
@@ -43,20 +43,6 @@ class Utils
     }
 
     /**
-     * Return the current user's home directory. The directory will be returned
-     * with a '/' at the end.
-     *
-     * If the user's home directory cannot be found, empty string is returned.
-     *
-     * Note: this will only work on *nix environments.
-     */
-    static inline std::string get_home_directory()
-    {
-        // HOME must be set according to POSIX
-        return getenv("HOME") ? std::string(getenv("HOME")) + "/" : std::string{};
-    }
-
-    /**
      * lowercase and ascii string.
      *  Note: this will not work on multi-byte unicode strings
      */

--- a/src/Utils/Utils.h
+++ b/src/Utils/Utils.h
@@ -43,34 +43,17 @@ class Utils
     }
 
     /**
-     * Return the current user's home directory. The directory will be return
+     * Return the current user's home directory. The directory will be returned
      * with a '/' at the end.
      *
      * If the user's home directory cannot be found, empty string is returned.
      *
-     *  Note: this will only work on *nix environments.
+     * Note: this will only work on *nix environments.
      */
     static inline std::string get_home_directory()
     {
-        const char *homedir;
-
-        // If $HOME environment variable is not set, fallback to getting it from
-        // getpwuid
-        if ((homedir = getenv("HOME")) == nullptr)
-        {
-            homedir = getpwuid(getuid())->pw_dir;
-        }
-
-        std::string homedir_str{homedir};
-
-        // Add the '/' if the home directory was found
-        if (!homedir_str.empty())
-        {
-            homedir_str.push_back('/');
-            return homedir_str;
-        }
-
-        return std::string{};
+        // HOME must be set according to POSIX
+        return getenv("HOME") ? std::string(getenv("HOME")) + "/" : std::string{};
     }
 
     /**

--- a/tests/UtilsTest.cpp
+++ b/tests/UtilsTest.cpp
@@ -42,14 +42,6 @@ TEST(UtilsTest, LowercaseEmptyString)
     EXPECT_EQ(expected, actual) << "lowercase must work with an empty string";
 }
 
-TEST(UtilsTest, GetHomeDirectory)
-{
-    auto actual = vis::Utils::get_home_directory();
-
-    EXPECT_FALSE(actual.empty())
-        << "get home directory should not return an empty string";
-}
-
 TEST(UtilsTest, ToBoolEmptyString)
 {
     auto actual = vis::Utils::to_bool("");


### PR DESCRIPTION
These changes make vis honor the [xdg base dir specs](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) at least partially. The install script places things in their correct places already, but the vis didn't seem to honor `XDG_CONFIG_HOME`.

Another thing to note [HOME must be set by POSIX](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html), I made that assumption when making these changes. 

Let me know if you want anything changed, I just want support for custom config directories. Thanks, you've made a pretty neat program!

PS: Is it possible to enable pulseaudio by default? I keep forgetting to do it, and wondering why nothing works. (maybe we could add an error when pulse hasn't been enabled but has been enabled in vis config)?