### PR TITLE
OSX El Capitan and compile fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CXX=$(VIS_COMPILER)
 endif
 
 ifndef PREFIX
-PREFIX=/bin/
+PREFIX=/usr/local/bin/
 endif
 
 DIR=$(shell pwd)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CXX=$(VIS_COMPILER)
 endif
 
 ifndef PREFIX
-PREFIX=/usr/local/bin/
+PREFIX=/bin/
 endif
 
 DIR=$(shell pwd)
@@ -62,6 +62,7 @@ PERF_TEST_CXX_FLAGS += -ggdb -g2
 
 ifeq ($(OS),Darwin)
 CXX_FLAGS += -dynamic -D_OS_OSX -D_XOPEN_SOURCE_EXTENDED
+
 else
 CXX_FLAGS += -D_LINUX
 endif
@@ -72,6 +73,8 @@ PERF_TEST_LD_FLAGS = -fno-omit-frame-pointer
 
 ifeq ($(OS),Darwin)
 LD_FLAGS += -D_XOPEN_SOURCE_EXTENDED
+#El Capitan has SIP, so things need to live in usr/local/bin now.
+PREFIX=/usr/local/bin/
 endif
 
 # DEBUG Settings

--- a/src/Domain/VisConstants.h
+++ b/src/Domain/VisConstants.h
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdlib>
 #include "Domain/VisTypes.h"
 
 namespace VisConstants


### PR DESCRIPTION
Made a change to make compile happen appropriately. Also fixed the install in the makefile so that it installs in the place compiled software goes these days in the OSX world.