### PR TITLE
Fix typo in example config

### DIFF
--- a/examples/config
+++ b/examples/config
@@ -35,7 +35,7 @@
 ##background will be colored instead of the character. Defaults to " ".
 #visualizer.spectrum.character=#
 
-##Spectrum bar width. Defaults to 1.
+##Spectrum bar width. Defaults to 2.
 #visualizer.spectrum.bar.width=2
 
 ##The amount of space between each bar in the spectrum visualizer. Defaults to 1. It's possible to set this to


### PR DESCRIPTION
The config file says the bar width will default to 1 while the default is 2.