### PR TITLE
Fix for building on Alpine Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ CXX_FLAGS += -march=$(VIS_COMPILER_ARCH)
 CXX_FLAGS += -ffast-math
 CXX_FLAGS += -fno-omit-frame-pointer
 CXX_FLAGS += -D__extern_always_inline=inline
+CXX_FLAGS += -D_XOPEN_SOURCE_EXTENDED
 
 TEST_CCACHE_CLANG=ccache clang++
 TEST_CLANG=clang++
@@ -68,7 +69,7 @@ PERF_TEST_CXX_FLAGS += -ggdb -g2
 
 # Mac OS
 ifeq ($(OS),Darwin)
-CXX_FLAGS += -dynamic -D_OS_OSX -D_XOPEN_SOURCE_EXTENDED
+CXX_FLAGS += -dynamic -D_OS_OSX
 
 # Linux
 else


### PR DESCRIPTION
Adding `-D_XOPEN_SOURCE_EXTENDED` to CXX_FLAGS will enable wide character support in ncurses on Alpine Linux. (Thanks to @dtzWill for finding that!)

`-D_XOPEN_SOURCE_EXTENDED` Will now be added by default to CXX_FLAGS.

I used the following commands to build vis in a docker container:
```
# Local machine
docker run --rm -it --workdir /tmp alpine:latest sh

# Inside the docker container
apk update
apk add git fftw-dev ncurses-dev make g++
git clone https://github.com/DuckThom/cli-visualizer vis
cd vis
make
```

This change should fix #48 