### PR TITLE
edits in Makefile to fix segmentation fault issue on Gentoo and README.md to add entries for Gentoo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,20 @@ CXX_FLAGS += -dynamic -D_OS_OSX
 # Linux
 else
 CXX_FLAGS += -D_LINUX
-LIBS += -ltinfo
+ifdef VIS_NCURSES_LIB_PATH
+	LIBS += -ltinfow
+else
+#if this box has an older version of ncurses
+ifneq ("$(wildcard /usr/include/ncursesw/ncurses.h)","")
+	LIBS += -ltinfow
+else
+ifdef VIS_NCURSESW
+	LIBS += -ltinfow
+else
+	LIBS += -ltinfo
+endif
+endif
+endif
 ifndef ENABLE_PULSE
 CHECK_PULSE=$(shell ldconfig -p | grep libpulse-simple)
 ifeq ($(strip $(CHECK_PULSE)),)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     - [Arch Linux](#arch-linux)
     - [Fedora](#fedora)
     - [Solus](#solus)
+    - [Gentoo](#gentoo)
     - [Mac OS X](#mac-os-x)
   - [Installing](#installing)
     - [Arch Linux](#arch-linux-1)
@@ -116,6 +117,7 @@ Solus requires a handful of development packages and creating a link for libtinf
 	./install.sh
 	
 ### Gentoo
+
 Make sure to compile ncurses with tinfo flag, have clang and ccache installed on your Gentoo system.
 	
 	sudo USE="tinfo" emerge ncurses

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Solus requires a handful of development packages and creating a link for libtinf
 	sudo ln -s /usr/lib/libtinfo.so.5 /usr/lib/libtinfo.so
 	
 	./install.sh
+	
+### Gentoo
+Make sure to compile ncurses with tinfo flag, have clang and ccache installed on your Gentoo system.
+	
+	sudo USE="tinfo" emerge ncurses
+	sudo emerge clang ccache
 
 ### Mac OS X
 


### PR DESCRIPTION
if are on gentoo and you haven't compiled ncurses with the tinfo flag, cli-visualizer wont compile when you run ./install.sh. after compiling ncurses with tinfo flag, you can run the install.sh and it will successfully compile but it will give you a segmentation fault error when you run vis. to fix that, i've made changes in the LIBS line.