### PR TITLE
Fix fedora pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ In arch, the ncursesw is bundled with the ncurses package.
 
 ### Fedora
 
-	sudo dnf install fftw-devel ncurses-devel pulseaudio-libs-devel cmake-devel
+	sudo dnf install fftw-devel ncurses-devel pulseaudio-libs-devel cmake
 	
 ### Solus
 


### PR DESCRIPTION
'cmake-devel' does not exist in the current repositories. 'cmake' is enough. 

https://developer.fedoraproject.org/tech/languages/c/cmake.html