### PR TITLE
Fix LD flag setting in Pulse section

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ find_library(PULSE_FOUND NAMES pulse)
 if(PULSE_FOUND)
   set(DYNAMIC_LIBRARIES ${DYNAMIC_LIBRARIES} pulse pulse-simple)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_ENABLE_PULSE")
-  set(CMAKE_LD_FLAGS "${CMAKE_CXX_FLAGS} -D_ENABLE_PULSE")
+  set(CMAKE_LD_FLAGS "${CMAKE_LD_FLAGS} -D_ENABLE_PULSE")
 endif()
 
 ########################################################################


### PR DESCRIPTION
Addressing issue #127: In [CMakeLists.txt](), the PulseAudio section which adds `-D_ENABLE_PULSE` to `CMAKE_CXX_FLAGS` and `CMAKE_LD_FLAGS` overwrites the latter flags list with the former. Changing this to follow the convention elsewhere in this file, as well as prevent the overwriting of `CMAKE_LD_FLAGS`