### PR TITLE
Fix minor typo in readme: 16 terminal colors are 0-15

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Color index color scheme example
 
 ![basic_colors](http://i.imgur.com/TUrQU01l.gif "Basic Colors")
 
-All the basic 16 terminal colors from 0-16 in-order. The spectrum colors can be ordered in any you want, this example was done in order to show all colors.
+All the basic 16 terminal colors from 0-15 in-order. The spectrum colors can be ordered in any you want, this example was done in order to show all colors.
 
 <br><br>
 


### PR DESCRIPTION
I know this is a really minor issue, but the typo confused me for a bit so I thought I would fix it. There are 16 terminal colors indexed as 0-15 (0-16 would be 17), and attempting to set color 16 in the config would not work.